### PR TITLE
feat: adiciona dois campos opcionais para o cadastro de uma despesa

### DIFF
--- a/src/expense/dtos/createExpense.dto.ts
+++ b/src/expense/dtos/createExpense.dto.ts
@@ -45,4 +45,21 @@ export class CreateExpenseDto {
   @IsOptional()
   description?: string;
 
+  @ApiPropertyOptional({
+    example: 12,
+    description: 'My car consumes 1L per 10 km',
+  })
+  @IsNumber()
+  @IsOptional()
+  @Transform(({ value }) => parseFloat(value))
+  kilometerPerLiter?: number;
+
+  @ApiPropertyOptional({
+    example: 100,
+    description: 'Distance traveled',
+  })
+  @IsNumber()
+  @IsOptional()
+  @Transform(({ value }) => parseFloat(value))
+  distance?: number;
 }

--- a/src/expense/expense.controller.ts
+++ b/src/expense/expense.controller.ts
@@ -42,6 +42,8 @@ export class ExpenseController {
         date: { type: 'string', format: 'date-time', example: '2023-05-20T14:48:00.000Z' },
         description: { type: 'string', example: 'Lunch at a restaurant' },
         image: { type: 'string', format: 'binary' },
+        kilometerPerLiter: { type: 'number', example: 10 },
+        distance: { type: 'number', example: 100 }
       },
     },
   })

--- a/src/expense/expense.schema.ts
+++ b/src/expense/expense.schema.ts
@@ -20,6 +20,12 @@ export class Expense {
 
   @Prop({ type: Types.ObjectId, ref: 'Request' })
   request: Types.ObjectId;
+
+  @Prop()
+  kilometerPerLiter: number;
+
+  @Prop()
+  distance: number;
 }
 
 export const ExpenseSchema = SchemaFactory.createForClass(Expense);

--- a/src/expense/expense.service.ts
+++ b/src/expense/expense.service.ts
@@ -85,6 +85,17 @@ export class ExpenseService {
         request.isOverLimit = true;
       }
 
+      if (createExpenseDto.kilometerPerLiter && createExpenseDto.distance) {
+        const kmPerLiter = createExpenseDto.kilometerPerLiter;
+        const distance = createExpenseDto.distance;
+        const gasolinePrice = 6.28; // considera valor médio nacional do litro da gasolina como R$6,28
+
+        if (!isNaN(kmPerLiter) && !isNaN(distance) && kmPerLiter > 0) {
+          const fuelValue = (distance / kmPerLiter) * gasolinePrice;
+          createExpenseDto.value = parseFloat(fuelValue.toFixed(2));
+        }
+      }
+
       const expense = new this.expenseModel({
         ...createExpenseDto,
         image: fileKey,

--- a/src/utils/generateCode.ts
+++ b/src/utils/generateCode.ts
@@ -1,6 +1,6 @@
 export default function generateCode(length: number) {
   const characters =
-    '1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
+    '1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ';
   let code: string = '';
 
   for (let x = 0; x < length; x++) {


### PR DESCRIPTION
Adiciona dois campos opcionais para o cadastro de uma despesa:
- Km/Litro
- Distancia percorrida

O calculo do valor é feito na api -> (distancia/ km/litro) * preço médio da gasolina

obs: o campo valor é obrigatorio na api, então quando for cadastrar uma despesa do tipo "GASOLINA", enviar no payload o valor da despesa inicialmente como 0, porque a api altera esse valor.